### PR TITLE
refactor: 修改几处代码的写法，基本不影响逻辑

### DIFF
--- a/src-tauri/src/ai_translator.rs
+++ b/src-tauri/src/ai_translator.rs
@@ -286,14 +286,7 @@ pub async fn translate_with_gpt(app: &AppHandle, original: &str) -> Result<Strin
 
     // 解析响应
     println!("API响应原文: {:?}", response);
-    let translated = match response
-        .get("choices")
-        .and_then(|choices| choices.as_array())
-        .and_then(|choices| choices.first())
-        .and_then(|choice| choice.get("message"))
-        .and_then(|message| message.get("content"))
-        .and_then(|content| content.as_str())
-    {
+    let translated = match response["choices"][0]["message"]["content"].as_str() {
         Some(text) => {
             let text = text.trim();
             // 如果找到</think>标签，只保留其后内容

--- a/src-tauri/src/store.rs
+++ b/src-tauri/src/store.rs
@@ -58,6 +58,46 @@ pub struct AppSettings {
     pub phrases: Vec<Phrase>,
 }
 
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            trans_hotkey: HotkeyConfig::new_platform_specific("KeyT"),
+            translation_from: "zh".to_string(),
+            translation_to: "en".to_string(),
+            game_scene: "dota2".to_string(),
+            translation_mode: "toxic".to_string(),
+            daily_mode: false,
+            model_type: "deepseek".to_string(),
+            custom_model: ModelConfig {
+                auth: "".to_string(),
+                api_url: "https://api.openai.com/v1/chat/completions".to_string(),
+                model_name: "gpt-3.5-turbo".to_string(),
+            },
+            phrases: [
+                "已使自身本场比赛的积分得失加倍！",
+                "由于挂机行为已经被系统从游戏中踢出...",
+                "已经放弃了游戏，这场比赛不计入天梯积分，剩余玩家可以自由退出。",
+                "由于长时间没有重连至游戏，系统判定他为逃跑。玩家现在离开该场比赛将不会被判定为放弃！",
+                "已经放弃了游戏，系统判定他为逃跑。玩家现在离开该场比赛将不会被判定为放弃。",
+                "检测到网络的连接情况非常糟糕，本场比赛将不会计入数据。现在可以安全离开比赛。",
+                "已经连续258次预测他们队伍将取得胜利！",
+                "经系统检测：玩家XXXXXX存在代练或共享账号嫌疑，遵守社区游戏规范，再次违反将进行封禁处理。",
+            ]
+            .into_iter()
+            .enumerate()
+            .map(|(idx, phrase)| {
+                let id = idx as i32 +1;
+                Phrase {
+                    id,
+                    phrase: phrase.to_string(),
+                    hotkey: HotkeyConfig::new_platform_specific(&format!("Digit{}", id)),
+                }
+            })
+            .collect()
+        }
+    }
+}
+
 // 初始化默认设置
 pub fn initialize_settings(app: &AppHandle) -> Result<(), anyhow::Error> {
     let store = app.store(STORE_FILENAME)?;
@@ -68,48 +108,8 @@ pub fn initialize_settings(app: &AppHandle) -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
-    // 创建默认快捷键配置
-    let trans_hotkey = HotkeyConfig::new_platform_specific("KeyT");
-
-    // 创建默认常用语配置
-    let phrases: Vec<Phrase> = (1..=8).map(|id| {
-        let phrase = match id {
-            1 => "已使自身本场比赛的积分得失加倍！",
-            2 => "由于挂机行为已经被系统从游戏中踢出...",
-            3 => "已经放弃了游戏，这场比赛不计入天梯积分，剩余玩家可以自由退出。",
-            4 => "由于长时间没有重连至游戏，系统判定他为逃跑。玩家现在离开该场比赛将不会被判定为放弃！",
-            5 => "已经放弃了游戏，系统判定他为逃跑。玩家现在离开该场比赛将不会被判定为放弃。",
-            6 => "检测到网络的连接情况非常糟糕，本场比赛将不会计入数据。现在可以安全离开比赛。",
-            7 => "已经连续258次预测他们队伍将取得胜利！",
-            8 => "经系统检测：玩家XXXXXX存在代练或共享账号嫌疑，遵守社区游戏规范，再次违反将进行封禁处理。",
-            _ => unreachable!(),
-        };
-        
-        Phrase {
-            id,
-            phrase: phrase.to_string(),
-            hotkey: HotkeyConfig::new_platform_specific(&format!("Digit{}", id)),
-        }
-    }).collect();
-
-    let default_settings = json!({
-        "trans_hotkey": trans_hotkey,
-        "translation_from": "zh",
-        "translation_to": "en",
-        "game_scene": "dota2",
-        "translation_mode": "toxic",
-        "daily_mode": false,
-        "model_type": "deepseek",
-        "custom_model": {
-            "auth": "",
-            "api_url": "https://api.openai.com/v1/chat/completions",
-            "model_name": "gpt-3.5-turbo"
-        },
-        "phrases": phrases
-    });
-
-    store.set("settings", default_settings);
-    let _ = store.save();
+    store.set("settings", json!(AppSettings::default()));
+    store.save()?;
     store.close_resource();
 
     Ok(())


### PR DESCRIPTION
主要是修改写法，只有第四点会些许影响逻辑，但感觉原来忽略保存错误是 bug？（

1. 解析响应部分修改为等价的连续索引
2. 使用常规的 `impl Default` 实现默认值
3. 构造 `phrases` 时使用 `[].into_iter().enumerate()` 代替 `(1..=8).map(|id| match id { ... })`
4. `let _ = store.save();` 修改为 `store.save()?;` 以正确进行错误传播